### PR TITLE
Add shared layout template

### DIFF
--- a/src/views/error.njk
+++ b/src/views/error.njk
@@ -1,27 +1,5 @@
-{% extends "govuk/template.njk" %}
-{% block head %}
-  <!--[if !IE 8]><!-->
-    <link href="/stylesheets/application.css" rel="stylesheet">
-  <!--<![endif]-->
-
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-{% endblock %}
+{% extends "layout.njk" %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">Default error template</h1>
-{% endblock %}
-
-{% block bodyEnd %}
-  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src="/javascripts/govuk-frontend/all.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -1,27 +1,5 @@
-{% extends "govuk/template.njk" %}
-{% block head %}
-  <!--[if !IE 8]><!-->
-    <link href="/stylesheets/application.css" rel="stylesheet">
-  <!--<![endif]-->
-
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-{% endblock %}
+{% extends "layout.njk" %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">Default page template</h1>
-{% endblock %}
-
-{% block bodyEnd %}
-  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src="/javascripts/govuk-frontend/all.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -1,0 +1,25 @@
+{% extends "govuk/template.njk" %}
+{% block head %}
+  <!--[if !IE 8]><!-->
+    <link href="/stylesheets/application.css" rel="stylesheet">
+  <!--<![endif]-->
+
+  {# For Internet Explorer 8, you need to compile specific stylesheet #}
+  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
+  <!--[if IE 8]>
+    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
+  <![endif]-->
+
+  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
+  <!--[if lt IE 9]>
+    <script src="/html5-shiv/html5shiv.js"></script>
+  <![endif]-->
+{% endblock %}
+
+{% block content %}{% endblock %}
+
+{% block bodyEnd %}
+  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
+  <script src="/javascripts/govuk-frontend/all.js"></script>
+  <script>window.GOVUKFrontend.initAll()</script>
+{% endblock %}

--- a/src/views/login/start.njk
+++ b/src/views/login/start.njk
@@ -1,22 +1,5 @@
-{% extends "govuk/template.njk" %}
+{% extends "layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
-{% block head %}
-  <!--[if !IE 8]><!-->
-    <link href="/stylesheets/application.css" rel="stylesheet">
-  <!--<![endif]-->
-
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-{% endblock %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">Default page template</h1>
@@ -28,10 +11,4 @@
     }) }}
   </form>
 
-{% endblock %}
-
-{% block bodyEnd %}
-  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src="/javascripts/govuk-frontend/all.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/views/login/success.njk
+++ b/src/views/login/success.njk
@@ -1,30 +1,6 @@
-{% extends "govuk/template.njk" %}
+{% extends "layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
-{% block head %}
-  <!--[if !IE 8]><!-->
-    <link href="/stylesheets/application.css" rel="stylesheet">
-  <!--<![endif]-->
-
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-{% endblock %}
 
 {% block content %}
   <p class="govuk-body">Logged in with the WebID {{ webId }}.</p>
-
-{% endblock %}
-
-{% block bodyEnd %}
-  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src="/javascripts/govuk-frontend/all.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}


### PR DESCRIPTION
Add shared template extending the design system's basic layout template, with the addition of some code at the end of `head` and `body`.