### PR TITLE
Deploy app to `hackathon.solid.integration.account.gov.uk`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:16.16.0-alpine as builder
+WORKDIR /app
+COPY package.json ./
+COPY package-lock.json ./
+COPY tsconfig.json ./
+COPY ./src ./src
+RUN npm ci && npm run build && rm -rf node_modules && npm ci --production
+
+FROM node:16.16.0-alpine as final
+WORKDIR /app
+COPY --chown=node:node --from=builder /app/package*.json ./
+COPY --chown=node:node --from=builder /app/node_modules/ node_modules
+COPY --chown=node:node --from=builder /app/dist/ dist
+
+ENV NODE_ENV "production"
+
+EXPOSE 3000
+USER node
+CMD ["npm", "start"]
+

--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@
 2. Run `npm run build` to build the app
 3. Run `npm start` to start the local server
 4. Visit `http://localhost:3000` in your browser
+
+## Deploying the app
+
+There's a Dockerfile and CloudFormation template in `/deploy`.
+To deploy the app, make sure you have AWS SAM installed and run `/deploy/deploy.sh` with the appropriate AWS credentials:
+
+```bash
+cd deploy
+gds aws di-solid-protoype -- ./deploy.sh
+```
+

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+
+tag=$(git rev-parse --short HEAD)
+
+ecr_registry=626456592666.dkr.ecr.eu-west-2.amazonaws.com
+ecr_repository=hackathon-app
+
+docker build -t $ecr_registry/$ecr_repository:$tag ../
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ecr_registry
+docker push $ecr_registry/$ecr_repository:$tag
+sam deploy --parameter-overrides ParameterKey=ImageTag,ParameterValue=$tag --confirm-changeset
+

--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -1,0 +1,9 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+region = "eu-west-2"
+stack_name = "hackathon-app"
+confirm_changeset = true
+capabilities = "CAPABILITY_NAMED_IAM"
+image_repositories = []

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1,0 +1,230 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: "Deploy the PDS hackathon app frontend"
+
+Parameters:
+  ContainerPort:
+    Type: Number
+    Default: 3000
+  CommonStackName:
+    Type: String
+    Default: common
+  ImageTag:
+    Type: String
+    Default: abc
+  ApplicationName:
+    Type: String
+    Default: hackathon-app
+
+Resources:
+  ContainerRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      ImageTagMutability: IMMUTABLE
+      RepositoryName: !Ref ApplicationName 
+
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      CapacityProviders: [
+        "FARGATE_SPOT"
+      ]
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      NetworkMode: awsvpc
+      Cpu: '256'
+      Memory: '512'
+      RequiresCompatibilities:
+        - FARGATE
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      ContainerDefinitions:
+        - Name: !Ref ApplicationName 
+          Cpu: '256'
+          Memory: '512'
+          Image: !Join ['', [!GetAtt ContainerRepository.RepositoryUri, ':', !Ref ImageTag]]
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+          Environment:
+            - Name: NODE_ENV
+              Value: production
+
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn: LoadBalancerRule
+    Properties:
+      ServiceName: !Ref ApplicationName 
+      Cluster: !GetAtt ECSCluster.Arn
+      LaunchType: FARGATE
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 15
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref ContainerSecurityGroup
+          Subnets:
+            - Fn::ImportValue:
+                Fn::Sub: "${CommonStackName}-PublicSubnet1ID"
+            - Fn::ImportValue:
+                Fn::Sub: "${CommonStackName}-PublicSubnet2ID"
+      TaskDefinition: !Ref TaskDefinition
+      LoadBalancers:
+        - ContainerName: !Ref ApplicationName
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref TargetGroup
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckPath: /
+      HealthCheckIntervalSeconds: 10
+      HealthCheckTimeoutSeconds: 6
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      TargetType: ip
+      Name: !Join ['-', [!Ref ApplicationName, TargetGroup]]
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      VpcId:
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-VPCID"
+
+  LoadBalancerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: 'forward'
+      Conditions:
+        - Field: path-pattern
+          Values: ['*']
+      ListenerArn: !Ref LoadBalancerListener
+      Priority: 1
+
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', [!Ref ApplicationName, ExecutionRole]]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', [!Ref ApplicationName, TaskRole]]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  ContainerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join ['-', [!Ref ApplicationName, ContainerSecurityGroup]]
+      VpcId:
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-VPCID"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref ContainerPort
+          ToPort: !Ref ContainerPort
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join ['-', [!Ref ApplicationName, LoadBalancerSecurityGroup]]
+      VpcId:
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-VPCID"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Join ['-', [!Ref ApplicationName, LoadBalancer]]
+      Scheme: internet-facing
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+      Subnets:
+        - Fn::ImportValue:
+            Fn::Sub: "${CommonStackName}-PublicSubnet1ID"
+        - Fn::ImportValue:
+            Fn::Sub: "${CommonStackName}-PublicSubnet2ID"
+
+  LoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: "redirect"
+          RedirectConfig:
+            Protocol: "HTTPS"
+            Port: 443
+            Host: "#{host}"
+            Path: "/#{path}"
+            Query: "#{query}"
+            StatusCode: "HTTP_301"
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+
+  HTTPSLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+      - CertificateArn: !Ref HTTPSCertificate
+
+  HTTPSCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: hackathon.solid.integration.account.gov.uk
+      DomainValidationOptions:
+        - DomainName: hackathon.solid.integration.account.gov.uk
+          HostedZoneId:
+            Fn::ImportValue:
+              Fn::Sub: "${CommonStackName}-SolidRoute53"
+      ValidationMethod: DNS
+
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: hackathon.solid.integration.account.gov.uk 
+      ResourceRecords:
+        - !GetAtt LoadBalancer.DNSName
+      HostedZoneId:
+        Fn::ImportValue:
+          Fn::Sub: "${CommonStackName}-SolidRoute53"
+      Type: CNAME
+      TTL: 3000
+


### PR DESCRIPTION
This PR adds a Dockerfile, Cloudformation template, and deploy script to deploy the app to ESC / Fargate at [hackathon.solid.integration.account.gov.uk](https://hackathon.solid.integration.account.gov.uk).

This is almost completely copied from [the Solid PoC app ](https://github.com/alphagov/di-solid-prototype/tree/main/infrastructure/prototype-app) and is designed to be deployed in the same AWS account so we can use the common VPC and DNS records.

The app's already deployed, so this PR can be tested by going to the above domain and checking the app is running. 

I'll raise a follow up PR to update the login controller so it works with the domain name.