### PR TITLE
Allow login when app is deployed

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,3 +5,19 @@ export function getPort() {
 export function getSessionKeys() {
   return ["key1", "key2"];
 }
+
+export function getDeployedDomain() {
+  return "hackathon.solid.integration.account.gov.uk";
+}
+
+export function getProtocol() {
+  return process.env.NODE_ENV === "production" ? "https" : "http";
+}
+
+export function getHostname() {
+  const hostname =
+    process.env.NODE_ENV === "production"
+      ? getDeployedDomain()
+      : `localhost:${getPort()}`;
+  return `${getProtocol()}://${hostname}`;
+}

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -4,9 +4,7 @@ import {
   Session,
 } from "@inrupt/solid-client-authn-node";
 
-import { getPort } from "../config";
-
-const port = getPort();
+import { getHostname } from "../config";
 
 export async function loginGet(req: Request, res: Response): Promise<void> {
   res.render("login/start");
@@ -21,7 +19,7 @@ export async function loginPost(req: Request, res: Response): Promise<void> {
     res.redirect(url);
   };
   await session.login({
-    redirectUrl: `http://localhost:${port}/login/callback`,
+    redirectUrl: `${getHostname()}/login/callback`,
     oidcIssuer: "https://login.inrupt.com",
     clientName: "GDS PDS prototype app",
     handleRedirect: redirectToSolidIdentityProvider,
@@ -31,7 +29,7 @@ export async function loginPost(req: Request, res: Response): Promise<void> {
 export async function callbackGet(req: Request, res: Response): Promise<void> {
   const session = await getSessionFromStorage(req.session?.sessionId);
   await session?.handleIncomingRedirect(
-    `http://localhost:${port}${req.originalUrl}`
+    `${getHostname()}${req.originalUrl}`
   );
 
   if (session?.info.isLoggedIn) {


### PR DESCRIPTION
Follow up PR to #2. This removes the hardcoded `localhost` URLs in the login controller and generates them from a new helper function in `config.ts`.

This is again almost entirely copied from the Solid PoC frontend app.