### PR TITLE
Fix 404 errors with assets

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -41,9 +41,7 @@ app.set("view engine", "njk");
 
 app.use(
   "/assets",
-  express.static(
-    path.join(__dirname, "/node_modules/govuk-frontend/govuk/assets")
-  )
+  express.static(path.resolve("node_modules/govuk-frontend/govuk/assets"))
 );
 
 // Set up server


### PR DESCRIPTION
The static assets from GOV.UK Frontend weren't being served by the app, probably because `path.join` wasn't finding a valid directory.

Switch to `path.resolve` like in the proof of concept app which does work.