### PR TITLE
Model vouch data

### DIFF
--- a/src/lib/models/vouch.ts
+++ b/src/lib/models/vouch.ts
@@ -1,0 +1,26 @@
+export type Url = string;
+export type WebId = Url;
+
+export type Name = string;
+
+export enum VouchRequestStatusStates {
+  Successful = "successful",
+  Unsuccessful = "unsuccessful",
+  Pending = "pending",
+}
+
+export interface VouchRequest {
+  voucher: WebId;
+  vouchee: WebId;
+  status: Url;
+  name: Name;
+  photo: Url;
+  issued: Date;
+  expires: Date;
+  id: String;
+}
+
+export interface VouchRequestStatus {
+  status: VouchRequestStatusStates;
+  vouchRequest: Url;
+}

--- a/src/lib/models/vouch.ts
+++ b/src/lib/models/vouch.ts
@@ -24,3 +24,17 @@ export interface VouchRequestStatus {
   status: VouchRequestStatusStates;
   vouchRequest: Url;
 }
+
+export interface VouchedFor {
+  vouchee: WebId;
+  issued: Date;
+  vouchResource: Url;
+  vouchRequest: Url;
+}
+
+export interface RecievedVouchFrom {
+  voucher: WebId;
+  issued: Date;
+  vouchForResource: Url;
+  vouchRequest: Url;
+}


### PR DESCRIPTION
Add data models for vouch requests and completed vouches. 

When a user completes the request a vouch journey the app will create a `VouchRequest` and a `VouchRequestStatus` object in their pod.

Then once the vouchee completes their journey, the app will write a `VouchedFor` object into their pod and a `RecievedVouchFrom` object into the original user's pod. 