### PR TITLE
Save a fake photo to the app's storage 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,10 @@
         "i18next-fs-backend": "^1.1.5",
         "i18next-http-middleware": "^3.2.1",
         "morgan": "~1.9.1",
+        "node-fetch": "^2.6.1",
         "nunjucks": "^3.2.3",
-        "typescript": "^4.8.2"
+        "typescript": "^4.8.2",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.3",
@@ -30,6 +32,7 @@
         "@types/http-errors": "^1.8.2",
         "@types/i18next-fs-backend": "^1.1.2",
         "@types/morgan": "^1.9.3",
+        "@types/node-fetch": "^2.6.2",
         "@types/nunjucks": "^3.2.1",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
@@ -229,6 +232,14 @@
         "node": "^14.0.0 || ^16.0.0"
       }
     },
+    "node_modules/@inrupt/solid-client-authn-core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@inrupt/solid-client-authn-node": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.12.2.tgz",
@@ -242,6 +253,14 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@inrupt/solid-common-vocab": {
@@ -452,6 +471,16 @@
       "version": "18.7.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
       "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "node_modules/@types/nunjucks": {
       "version": "3.2.1",
@@ -1003,6 +1032,12 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/axe-core": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
@@ -1198,6 +1233,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -1345,6 +1392,25 @@
         "node-fetch": "2.6.7"
       }
     },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1402,6 +1468,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -2256,6 +2331,20 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3255,22 +3344,11 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "engines": {
         "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/nodemon": {
@@ -4489,9 +4567,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4502,6 +4580,16 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -4720,6 +4808,13 @@
         "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@inrupt/solid-client-authn-node": {
@@ -4732,6 +4827,13 @@
         "jose": "^4.3.7",
         "openid-client": "^5.1.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@inrupt/solid-common-vocab": {
@@ -4927,6 +5029,16 @@
       "version": "18.7.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
       "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
+    },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "@types/nunjucks": {
       "version": "3.2.1",
@@ -5307,6 +5419,12 @@
       "dev": true,
       "peer": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "axe-core": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
@@ -5457,6 +5575,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -5563,6 +5690,16 @@
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
         "node-fetch": "2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -5611,6 +5748,12 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -6263,6 +6406,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -6974,12 +7128,9 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "nodemon": {
       "version": "2.0.20",
@@ -7839,14 +7990,21 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "optional": true,
+      "peer": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --ignore-path .prettierignore --write \"**/*.+(js|ts|json)\"",
     "clean": "rm -rf dist",
     "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/public/stylesheets/application.scss dist/public/stylesheets/application.css --style compressed",
-    "copy-assets": "mkdir -p dist/public/javascripts/govuk-frontend && cp node_modules/govuk-frontend/govuk/all.js dist/public/javascripts/govuk-frontend && cp src/public/javascripts/application.js dist/public/javascripts && mkdir -p dist/locales && cp -R src/locales/* dist/locales",
+    "copy-assets": "mkdir -p dist/public/javascripts/govuk-frontend && cp node_modules/govuk-frontend/govuk/all.js dist/public/javascripts/govuk-frontend && cp src/public/javascripts/application.js dist/public/javascripts && mkdir -p dist/locales && cp -R src/locales/* dist/locales && mkdir -p dist/public/images",
     "copy-views": "mkdir -p dist/views && cp -R src/views/* dist/views",
     "build": "npm run clean && npm run build-sass && npm run copy-assets && npm run copy-views && tsc",
     "test": "npm run lint",
@@ -29,8 +29,10 @@
     "i18next-fs-backend": "^1.1.5",
     "i18next-http-middleware": "^3.2.1",
     "morgan": "~1.9.1",
+    "node-fetch": "^2.6.1",
     "nunjucks": "^3.2.3",
-    "typescript": "^4.8.2"
+    "typescript": "^4.8.2",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.3",
@@ -39,6 +41,7 @@
     "@types/http-errors": "^1.8.2",
     "@types/i18next-fs-backend": "^1.1.2",
     "@types/morgan": "^1.9.3",
+    "@types/node-fetch": "^2.6.2",
     "@types/nunjucks": "^3.2.1",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ import i18next from "i18next";
 import i18nextMiddleware from "i18next-http-middleware";
 import Backend from "i18next-fs-backend";
 import nunjucks, { Environment } from "nunjucks";
-  
+
 import { getPort, getSessionKeys } from "./config";
 
 import indexRouter from "./routes/index";
@@ -69,7 +69,6 @@ i18next
     },
   });
 
-
 app.use(i18nextMiddleware.handle(i18next));
 
 function configureNunjucks(expressApp: express.Application): Environment {
@@ -106,11 +105,11 @@ app.use(
 );
 
 // ============================
-// Set up 404 
+// Set up 404
 // ============================
 
 const notFoundHandler: RequestHandler = (req, res, next) => {
-    next(createError(404));
+  next(createError(404));
 };
 app.use(notFoundHandler);
 

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -30,6 +30,7 @@ export function voucheeYourNameGet(req: Request, res: Response): void {
 
 export function voucheeYourNamePost(req: Request, res: Response): void {
   if (req.session) {
+    console.log(req.body);
     req.session.fullName = req.body.fullName;
   }
   res.redirect("/vouch/request-vouch/provide-photo");
@@ -56,6 +57,7 @@ export function voucheeConfirmationGet(req: Request, res: Response): void {
   if (req.session) {
     res.render("vouch/request-vouch/confirmation", {
       imageUrl: req.session.photoUrl,
+      fullName: req.session.fullName,
     });
   }
 }

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -46,14 +46,18 @@ export async function voucheeProvidePhotoPost(
   const imageName = `${uuidv4()}.jpg`;
   await download("https://thispersondoesnotexist.com/image", imageName);
   if (req.session) {
-    req.session.photoUrl = `${getHostname}imagePath`;
+    req.session.photoUrl = `${getHostname()}/images/${imageName}`;
   }
   res.redirect("/vouch/request-vouch/confirmation");
 }
 
 // Confirmation page
 export function voucheeConfirmationGet(req: Request, res: Response): void {
-  res.render("vouch/request-vouch/confirmation");
+  if (req.session) {
+    res.render("vouch/request-vouch/confirmation", {
+      imageUrl: req.session.photoUrl,
+    });
+  }
 }
 
 // Journey completion page

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -1,4 +1,18 @@
+import fs from "fs";
+import fetch from "node-fetch";
+import path from "path";
 import { Request, Response } from "express";
+import { v4 as uuidv4 } from "uuid";
+import { Url } from "../lib/models/vouch";
+import { getHostname } from "../config";
+
+async function download(url: Url, fileName: string) {
+  const filePath = path.join(__dirname, "../", `public/images/${fileName}`);
+  const response = await fetch(url);
+  const buffer = await response.buffer();
+  fs.writeFileSync(filePath, buffer);
+  console.log(`finished downloading to ${filePath}!`);
+}
 
 // ======================================================
 // Journey 1 Request someone to vouch for you
@@ -14,7 +28,7 @@ export function voucheeYourNameGet(req: Request, res: Response): void {
   res.render("vouch/request-vouch/your-name");
 }
 
-export function voucheeYourNamePost(req:Request, res:Response): void {
+export function voucheeYourNamePost(req: Request, res: Response): void {
   if (req.session) {
     req.session.fullName = req.body.fullName;
   }
@@ -25,8 +39,15 @@ export function voucheeYourNamePost(req:Request, res:Response): void {
 export function voucheeProvidePhotoGet(req: Request, res: Response): void {
   res.render("vouch/request-vouch/provide-photo");
 }
-
-export function voucheeProvidePhotoPost(req: Request, res: Response): void {
+export async function voucheeProvidePhotoPost(
+  req: Request,
+  res: Response
+): Promise<void> {
+  const imageName = `${uuidv4()}.jpg`;
+  await download("https://thispersondoesnotexist.com/image", imageName);
+  if (req.session) {
+    req.session.photoUrl = `${getHostname}imagePath`;
+  }
   res.redirect("/vouch/request-vouch/confirmation");
 }
 
@@ -37,7 +58,7 @@ export function voucheeConfirmationGet(req: Request, res: Response): void {
 
 // Journey completion page
 export function voucheeDoneGet(req: Request, res: Response): void {
-  res.render("vouch/request-a-vouch/done");
+  res.render("vouch/request-vouch/done");
 }
 
 // ======================================================

--- a/src/routes/vouch.ts
+++ b/src/routes/vouch.ts
@@ -1,17 +1,17 @@
-import express, { Request, Response, NextFunction } from "express";
+import express from "express";
 
 import {
-    requestVouchGet,
-    vouchForSomeoneGet,
-    voucheeYourNameGet,
-    voucheeProvidePhotoGet,
-    voucheeConfirmationGet,
-    voucheeVoucherDetailsGet,
-    voucheeDoneGet,
-    voucheeYourNamePost,
-    voucheeProvidePhotoPost,
-  } from "../controllers/vouch";
-  
+  requestVouchGet,
+  vouchForSomeoneGet,
+  voucheeYourNameGet,
+  voucheeProvidePhotoGet,
+  voucheeConfirmationGet,
+  voucheeVoucherDetailsGet,
+  voucheeDoneGet,
+  voucheeYourNamePost,
+  voucheeProvidePhotoPost,
+} from "../controllers/vouch";
+
 const router = express.Router();
 
 router.get("/request-vouch", requestVouchGet);

--- a/src/views/vouch/request-vouch/confirmation.njk
+++ b/src/views/vouch/request-vouch/confirmation.njk
@@ -25,7 +25,7 @@
         Photo
       </dt>
       <dd class="govuk-summary-list__value">
-        <img src="asdfplaceholder.jpeg" alt="Face" width="150" height="150">
+        <img src={{ imageUrl }} alt="Face" width="150" height="150">
       </dd>
       <dd class="govuk-summary-list__actions">
         <a class="govuk-link" href="#">

--- a/src/views/vouch/request-vouch/confirmation.njk
+++ b/src/views/vouch/request-vouch/confirmation.njk
@@ -12,10 +12,10 @@
         Name
       </dt>
       <dd class="govuk-summary-list__value">
-        Jane Doe
+        {{ fullName }}
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link" href="#">
+        <a class="govuk-link" href="/vouch/request-vouch/your-name">
           Change<span class="govuk-visually-hidden"> name</span>
         </a>
       </dd>
@@ -28,7 +28,7 @@
         <img src={{ imageUrl }} alt="Face" width="150" height="150">
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link" href="#">
+        <a class="govuk-link" href="/vouch/request-vouch/provide-photo">
           Change<span class="govuk-visually-hidden"> photo</span>
         </a>
       </dd>

--- a/src/views/vouch/request-vouch/provide-photo.njk
+++ b/src/views/vouch/request-vouch/provide-photo.njk
@@ -5,7 +5,7 @@
 
 {% block content %}
     <h1 class="govuk-heading-xl">Upload a photo of yourself</h1>
-    <form class="form" action="/provide-photo" method="post">
+    <form class="form" action="/vouch/request-vouch/provide-photo" method="post">
       <p class="govuk-body">The person in a position of authority will need to confirm that your photo is a true likeness of you.</p>
       <p class="govuk-body">Your photo will go through a basic technical check.</p>
       <p class="govuk-body">Your photo must be:</p>

--- a/src/views/vouch/request-vouch/your-name.njk
+++ b/src/views/vouch/request-vouch/your-name.njk
@@ -4,14 +4,14 @@
 {% endblock %}
 
 {% block content %}
-  <form class="form" action="/your-name" method="post">
+  <form class="form" action="/vouch/request-vouch/your-name" method="post">
     <div class="govuk-form-group">
       <h1 class="govuk-label-wrapper">
         <label class="govuk-label govuk-label--xl" for="vouchee-name">
           What is your full name?
         </label>
       </h1>
-      <input class="govuk-input govuk-!-width-two-thirds" id="vouchee-name" name="vouchee-name" type="text">
+      <input class="govuk-input govuk-!-width-two-thirds" id="fullName" name="fullName" type="text">
     </div>
     <button class="govuk-button" data-module="govuk-button">Continue</button>
   </form>


### PR DESCRIPTION
In the real journey a user would upload a photo of themselves.
Instead, fetch a fake image from thispersondoesnotexist.com and
store that locally in the app and write its path to the user's
session.

This allows us to easily display the image on the next page
which will be the confirmation page (since it'll have a public URL)
at which point we can put it in the user's pod.

And display the image and user's name on the confirmation page.

<img width="717" alt="image" src="https://user-images.githubusercontent.com/6362602/191538767-fc5dc6de-d5de-4c78-8ffc-96bcf496eb9a.png">
