### PR TITLE
Make clear the vouch service is about identity

### DIFF
--- a/src/views/account/home.njk
+++ b/src/views/account/home.njk
@@ -36,16 +36,15 @@
       {% endfor %}
     </section>
   {% endif %}
-   <section class="accounts-panel">
-    <h2 class="govuk-heading-m">Ask for a vouch</h2>
+  <section class="accounts-panel">
+    <h2 class="govuk-heading-m">Ask for an identity vouch</h2>
     <p class="govuk-body">
-      A person vouches for someone else by declaring they know them as their claimed identity.
+      Someone who knows you can confirm who you are, if you need to prove your identity to a government service and do not have identity documents like a passport. This is known as ‘vouching’.
     </p>
     <p class="govuk-body">
-      <a class="govuk-link" href="/vouch/request-vouch">Ask someone to verify your identity</a>
+      <a class="govuk-link" href="/vouch/request-vouch">Ask someone to vouch for your identity</a>
     </p>
   </section>
-
   <section class="information-box">
     <h2 class="govuk-heading-m">{{ 'account.pages.home.aboutAccounts.heading' | translate }}</h2>
     <p class="govuk-body">{{ 'account.pages.home.aboutAccounts.paragraph1' | translate }}</p>


### PR DESCRIPTION
Update the vouching service panel heading to include the word 'identity' - other types of vouch are available (at the next table!)

Explain some more about what vouching is and why you might need it in the panel body