### PR TITLE
Improve voucher details flow

### DIFF
--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -30,7 +30,6 @@ export function voucheeYourNameGet(req: Request, res: Response): void {
 
 export function voucheeYourNamePost(req: Request, res: Response): void {
   if (req.session) {
-    console.log(req.body);
     req.session.fullName = req.body.fullName;
   }
   res.redirect("/vouch/request-vouch/provide-photo");
@@ -49,6 +48,18 @@ export async function voucheeProvidePhotoPost(
   if (req.session) {
     req.session.photoUrl = `${getHostname()}/images/${imageName}`;
   }
+  res.redirect("/vouch/request-vouch/voucher-details");
+}
+
+// Who is vouching for you?
+export function voucheeVoucherDetailsGet(req: Request, res: Response): void {
+  res.render("vouch/request-vouch/voucher-details");
+}
+
+export function voucheeVoucherDetailsPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.voucher = req.body.voucher;
+  }
   res.redirect("/vouch/request-vouch/confirmation");
 }
 
@@ -58,6 +69,7 @@ export function voucheeConfirmationGet(req: Request, res: Response): void {
     res.render("vouch/request-vouch/confirmation", {
       imageUrl: req.session.photoUrl,
       fullName: req.session.fullName,
+      voucher: req.session.voucher,
     });
   }
 }
@@ -73,8 +85,4 @@ export function voucheeDoneGet(req: Request, res: Response): void {
 
 export function vouchForSomeoneGet(req: Request, res: Response): void {
   res.render("govuk/vouch-for-someone");
-}
-
-export function voucheeVoucherDetailsGet(req: Request, res: Response): void {
-  res.render("vouch/request-vouch/voucher-details");
 }

--- a/src/routes/vouch.ts
+++ b/src/routes/vouch.ts
@@ -7,6 +7,7 @@ import {
   voucheeProvidePhotoGet,
   voucheeConfirmationGet,
   voucheeVoucherDetailsGet,
+  voucheeVoucherDetailsPost,
   voucheeDoneGet,
   voucheeYourNamePost,
   voucheeProvidePhotoPost,
@@ -24,6 +25,8 @@ router.get("/request-vouch/provide-photo", voucheeProvidePhotoGet);
 router.post("/request-vouch/provide-photo", voucheeProvidePhotoPost);
 
 router.get("/request-vouch/voucher-details", voucheeVoucherDetailsGet);
+router.post("/request-vouch/voucher-details", voucheeVoucherDetailsPost);
+
 router.get("/request-vouch/confirmation", voucheeConfirmationGet);
 router.get("/request-vouch/done", voucheeDoneGet);
 

--- a/src/views/vouch/request-vouch/confirmation.njk
+++ b/src/views/vouch/request-vouch/confirmation.njk
@@ -42,7 +42,7 @@
       </dd>
       <dd class="govuk-summary-list__actions">
         <a class="govuk-link" href="/vouch/request-vouch/voucher-details">
-          Change<span class="govuk-visually-hidden"> photo</span>
+          Change<span class="govuk-visually-hidden"> vouch</span>
         </a>
       </dd>
     </div>

--- a/src/views/vouch/request-vouch/confirmation.njk
+++ b/src/views/vouch/request-vouch/confirmation.njk
@@ -9,7 +9,7 @@
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        Name
+        Your full name
       </dt>
       <dd class="govuk-summary-list__value">
         {{ fullName }}
@@ -22,13 +22,26 @@
     </div>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        Photo
+        Your photo
       </dt>
       <dd class="govuk-summary-list__value">
         <img src={{ imageUrl }} alt="Face" width="150" height="150">
       </dd>
       <dd class="govuk-summary-list__actions">
         <a class="govuk-link" href="/vouch/request-vouch/provide-photo">
+          Change<span class="govuk-visually-hidden"> photo</span>
+        </a>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Who is vouching for you
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ voucher }}
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link" href="/vouch/request-vouch/voucher-details">
           Change<span class="govuk-visually-hidden"> photo</span>
         </a>
       </dd>

--- a/src/views/vouch/request-vouch/voucher-details.njk
+++ b/src/views/vouch/request-vouch/voucher-details.njk
@@ -5,12 +5,12 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl">Enter details of the person vouching for you</h1>
-   <form class="form" action="/voucher-details" method="post">
+   <form class="form" action="/vouch/request-vouch/voucher-details" method="post">
     <div class="govuk-form-group">
-      <label class="govuk-label govuk-label--s" for="voucher-webid">
+      <label class="govuk-label govuk-label--s" for="voucher">
         WebID
       </label>
-      <input class="govuk-input govuk-!-width-two-thirds" id="voucher-webid" name="voucher-webid" type="text">
+      <input class="govuk-input govuk-!-width-two-thirds" id="voucher" name="voucher" type="text">
     </div>
     <button class="govuk-button" data-module="govuk-button">Continue</button>
   </form>


### PR DESCRIPTION
Move the voucher details page one step earlier in the journey - before the confirmation page. This means we can have only one confirmation page and will probably make more sense for users.

Then add the vouchers details to that confirmation page 

<img width="717" alt="image" src="https://user-images.githubusercontent.com/6362602/191543262-dcf24535-3c77-4790-b701-42d5a99ef692.png">
