### PR TITLE
Tidy up homepage

### DIFF
--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% set pageTitleName = 'Identity reuse proof of concept' %}
+{% set pageTitleName = 'Vouching for identity prototype' %}
 {% set serviceName = 'GOV.UK account' %}
 
 {% block content %}
@@ -8,15 +8,19 @@
 
   <h2 class="govuk-heading-m">Journeys</h2>
 
+  <div>
   {{ govukButton({
       text: "Ask someone to vouch for you",
-      href: "/"
+      href: "/account"
   }) }}
+  </div>
 
+  <div>
   {{ govukButton({
       text: "Vouch for someone else",
       href: "/"
   }) }}
+  </div>
 
 
   <h2 class="govuk-heading-m">Pages</h2>
@@ -40,20 +44,4 @@
       href: "/login/clear-session"
   }) }}
 
-  <p class="govuk-body">To log out of the prototype you need to sign out of both Auth and the ESS Broker.</p>
-  <div>
-  {{ govukButton({
-      text: "Sign out from Auth (opens in new tab)",
-      href: "/login/logout-auth",
-      attributes: {"target": "_blank"}
-  }) }}
-  </div>
-
-  <div>
-  {{ govukButton({
-      text: "Sign out from ESS broker (opens in new tab)",
-      href: "/login/logout-ess",
-      attributes: {"target": "_blank"}
-  }) }}
-  </div>
 {% endblock %}


### PR DESCRIPTION
Remove the logout links - they won't work with podspaces Change the prototype title
Put the start buttons on separate lines
Link to the start of the 'request a vouch' journey in the account home