### PR TITLE
Fix text styling on confirmation page

### DIFF
--- a/src/views/vouch/request-vouch/confirmation.njk
+++ b/src/views/vouch/request-vouch/confirmation.njk
@@ -48,9 +48,9 @@
     </div>
   </dl>
 
-<p>When you confirm, we'll email the person you've asked to vouch for your identity - they'll receive the email straight away.</p>
+  <p class="govuk-body">When you confirm, we'll email the person you've asked to vouch for your identity - they'll receive the email straight away.</p>
 
-<p>They’ll have 14 days to vouch for your identity after they get the email.</p>
+  <p class="govuk-body">They’ll have 14 days to vouch for your identity after they get the email.</p>
 
   <form action="/form-handler" method="post" novalidate>
     <input type="hidden" name="answers-checked" value="true">


### PR DESCRIPTION
This was missing the `govuk-body` class so wasn't using the correct font.