### PR TITLE
Join up vouching journey

### DIFF
--- a/src/controllers/emails.ts
+++ b/src/controllers/emails.ts
@@ -9,10 +9,10 @@ export function youHaveBeenVouchedForGet(req: Request, res: Response): void {
 }
 
 export function voucherRequestGet(req: Request, res: Response): void {
-  const voucherName = req.query.voucherName ? req.query.voucherName : "Person";
+  const voucheeName = req.query.voucheeName ? req.query.voucheeName : "Person";
   if (req.session) {
-    req.session.voucherName = voucherName;
+    req.session.voucheeName = voucheeName;
   }
 
-  res.render("emails/voucher-request", { voucherName });
+  res.render("emails/voucher-request", { voucheeName });
 }

--- a/src/controllers/emails.ts
+++ b/src/controllers/emails.ts
@@ -9,9 +9,7 @@ export function youHaveBeenVouchedForGet(req: Request, res: Response): void {
 }
 
 export function voucherRequestGet(req: Request, res: Response): void {
-  const voucherName = req.params.voucherName
-    ? req.params.voucherName
-    : "Person";
+  const voucherName = req.query.voucherName ? req.query.voucherName : "Person";
   if (req.session) {
     req.session.voucherName = voucherName;
   }

--- a/src/controllers/emails.ts
+++ b/src/controllers/emails.ts
@@ -9,5 +9,12 @@ export function youHaveBeenVouchedForGet(req: Request, res: Response): void {
 }
 
 export function voucherRequestGet(req: Request, res: Response): void {
-  res.render("emails/voucher-request");
+  const voucherName = req.params.voucherName
+    ? req.params.voucherName
+    : "Person";
+  if (req.session) {
+    req.session.voucherName = voucherName;
+  }
+
+  res.render("emails/voucher-request", { voucherName });
 }

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -98,7 +98,11 @@ export function useSavedProofOfIdGet(req: Request, res: Response): void {
 
 // Pick vouchee out of a line-up
 export function confirmLikenessGet(req: Request, res: Response): void {
-  res.render("vouch/vouch-for-someone/confirm-likeness");
+  if (req.session) {
+    res.render("vouch/vouch-for-someone/confirm-likeness", {
+      voucherName: req.session.voucherName,
+    });
+  }
 }
 
 export function confirmLikenessPost(req: Request, res: Response): void {

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -84,7 +84,11 @@ export function voucheeDoneGet(req: Request, res: Response): void {
 // ======================================================
 
 export function vouchForSomeoneGet(req: Request, res: Response): void {
-  res.render("govuk/vouch-for-someone");
+  if (req.session) {
+    res.render("govuk/vouch-for-someone", {
+      voucherName: req.session.voucherName,
+    });
+  }
 }
 
 // Identity confirmation page after logging in to a GOV.UK account

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -87,7 +87,6 @@ export function vouchForSomeoneGet(req: Request, res: Response): void {
   res.render("govuk/vouch-for-someone");
 }
 
-
 // Identity confirmation page after logging in to a GOV.UK account
 export function useSavedProofOfIdGet(req: Request, res: Response): void {
   res.render("vouch/vouch-for-someone/use-saved-proof-of-identity");
@@ -96,6 +95,10 @@ export function useSavedProofOfIdGet(req: Request, res: Response): void {
 // Pick vouchee out of a line-up
 export function confirmLikenessGet(req: Request, res: Response): void {
   res.render("vouch/vouch-for-someone/confirm-likeness");
+}
+
+export function confirmLikenessPost(req: Request, res: Response): void {
+  res.redirect("/vouch/vouch-for-someone/confirm-details");
 }
 
 // Confirm vouchee details and read disclaimer

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -111,7 +111,11 @@ export function confirmLikenessPost(req: Request, res: Response): void {
 
 // Confirm vouchee details and read disclaimer
 export function confirmDetailsGet(req: Request, res: Response): void {
-  res.render("vouch/vouch-for-someone/confirm-details");
+  if (req.session) {
+    res.render("vouch/vouch-for-someone/confirm-details", {
+      voucherName: req.session.voucherName,
+    });
+  }
 }
 
 export function confirmDetailsPost(req: Request, res: Response): void {

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -124,5 +124,9 @@ export function confirmDetailsPost(req: Request, res: Response): void {
 
 // End of voucher journey
 export function voucherEndGet(req: Request, res: Response): void {
-  res.render("vouch/vouch-for-someone/done");
+  if (req.session) {
+    res.render("vouch/vouch-for-someone/done", {
+      voucherName: req.session.voucherName,
+    });
+  }
 }

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -86,7 +86,7 @@ export function voucheeDoneGet(req: Request, res: Response): void {
 export function vouchForSomeoneGet(req: Request, res: Response): void {
   if (req.session) {
     res.render("govuk/vouch-for-someone", {
-      voucherName: req.session.voucherName,
+      voucheeName: req.session.voucheeName,
     });
   }
 }
@@ -100,7 +100,7 @@ export function useSavedProofOfIdGet(req: Request, res: Response): void {
 export function confirmLikenessGet(req: Request, res: Response): void {
   if (req.session) {
     res.render("vouch/vouch-for-someone/confirm-likeness", {
-      voucherName: req.session.voucherName,
+      voucheeName: req.session.voucheeName,
     });
   }
 }
@@ -113,7 +113,7 @@ export function confirmLikenessPost(req: Request, res: Response): void {
 export function confirmDetailsGet(req: Request, res: Response): void {
   if (req.session) {
     res.render("vouch/vouch-for-someone/confirm-details", {
-      voucherName: req.session.voucherName,
+      voucheeName: req.session.voucheeName,
     });
   }
 }
@@ -126,7 +126,7 @@ export function confirmDetailsPost(req: Request, res: Response): void {
 export function voucherEndGet(req: Request, res: Response): void {
   if (req.session) {
     res.render("vouch/vouch-for-someone/done", {
-      voucherName: req.session.voucherName,
+      voucheeName: req.session.voucheeName,
     });
   }
 }

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -106,6 +106,10 @@ export function confirmDetailsGet(req: Request, res: Response): void {
   res.render("vouch/vouch-for-someone/confirm-details");
 }
 
+export function confirmDetailsPost(req: Request, res: Response): void {
+  res.redirect("/vouch/vouch-for-someone/done");
+}
+
 // End of voucher journey
 export function voucherEndGet(req: Request, res: Response): void {
   res.render("vouch/vouch-for-someone/done");

--- a/src/routes/vouch.ts
+++ b/src/routes/vouch.ts
@@ -12,6 +12,7 @@ import {
   voucheeYourNamePost,
   voucheeProvidePhotoPost,
   confirmLikenessGet,
+  confirmLikenessPost,
   confirmDetailsGet,
   voucherEndGet,
   useSavedProofOfIdGet,
@@ -34,10 +35,13 @@ router.post("/request-vouch/voucher-details", voucheeVoucherDetailsPost);
 router.get("/request-vouch/confirmation", voucheeConfirmationGet);
 router.get("/request-vouch/done", voucheeDoneGet);
 
-router.get("/vouch-for-someone/use-saved-proof-of-identity", useSavedProofOfIdGet);
+router.get(
+  "/vouch-for-someone/use-saved-proof-of-identity",
+  useSavedProofOfIdGet
+);
 router.get("/vouch-for-someone/confirm-likeness", confirmLikenessGet);
+router.post("/vouch-for-someone/confirm-likeness", confirmLikenessPost);
 router.get("/vouch-for-someone/confirm-details", confirmDetailsGet);
 router.get("/vouch-for-someone/done", voucherEndGet);
-
 
 export default router;

--- a/src/routes/vouch.ts
+++ b/src/routes/vouch.ts
@@ -14,6 +14,7 @@ import {
   confirmLikenessGet,
   confirmLikenessPost,
   confirmDetailsGet,
+  confirmDetailsPost,
   voucherEndGet,
   useSavedProofOfIdGet,
 } from "../controllers/vouch";
@@ -42,6 +43,7 @@ router.get(
 router.get("/vouch-for-someone/confirm-likeness", confirmLikenessGet);
 router.post("/vouch-for-someone/confirm-likeness", confirmLikenessPost);
 router.get("/vouch-for-someone/confirm-details", confirmDetailsGet);
+router.post("/vouch-for-someone/confirm-details", confirmDetailsPost);
 router.get("/vouch-for-someone/done", voucherEndGet);
 
 export default router;

--- a/src/views/emails/voucher-request.njk
+++ b/src/views/emails/voucher-request.njk
@@ -1,31 +1,29 @@
 {% extends "layouts/email.njk" %}
 
-{% set subjectLine = "Person wants you to confirm their identity" %}
+{% set subjectLine %} {{ voucherName }} wants you to confirm their identity {% endset %}
 
 {% block emailBody %}
-  <p class="govuk-body"><b>Person wants you to confirm their identity</b></p>
+  <p class="govuk-body"><b>{{ voucherName }} wants you to confirm their identity</b></p>
 
-<p class="govuk-body">Person would like to sign in to a government service. Before they can do this, they need to confirm their identity.<br><br>
+<p class="govuk-body">{{ voucherName }} would like to sign in to a government service. Before they can do this, they need to confirm their identity.<br><br>
 
-Person would like you to confirm their identity for them. </p>
+{{ voucherName }} would like you to confirm their identity for them. </p>
 
 <p class="govuk-body"><b>What you need to do</b></p>
 
 <p class="govuk-body"> We’ll ask you to:<br>
 <ul class="govuk-list govuk-list--bullet">
 <li>confirm your identity by entering your passport or driving licence details, or by taking other forms of ID to a Post Office</li>
-<li>check that the details Person has given for you, including your profession, are correct</li>
-<li>look at 6 photos and confirm which photo is of Person</li>
+<li>look at 6 photos and confirm which photo is of {{ voucherName }}</li>
 
 </ul>
 
 <p class="govuk-body">It should take about 10 minutes. <br><br>
 
 <b>How to do it</b> <br><br>
-Go to <a href='/8-voucherstart' class="govuk-link">www.gov.uk/confirm-identity </a> and enter your unique reference number: OIDV56789<br><br>
+Go to <a href='/vouch/vouch-for-someone' class="govuk-link">www.gov.uk/confirm-identity </a><br><br>
 
-You have 2 weeks to confirm Person’s identity. After 2 weeks, your unique reference number will no longer work. <br><br>
-
+You have 2 weeks to confirm {{ voucherName }}’s identity. After 2 weeks this request will expire and you will not be able to confirm their identity.<br><br>
 
 Digital Identity<br><br>
 GOV.UK<br><br>

--- a/src/views/emails/voucher-request.njk
+++ b/src/views/emails/voucher-request.njk
@@ -1,20 +1,20 @@
 {% extends "layouts/email.njk" %}
 
-{% set subjectLine %} {{ voucherName }} wants you to confirm their identity {% endset %}
+{% set subjectLine %} {{ voucheeName }} wants you to confirm their identity {% endset %}
 
 {% block emailBody %}
-  <p class="govuk-body"><b>{{ voucherName }} wants you to confirm their identity</b></p>
+  <p class="govuk-body"><b>{{ voucheeName }} wants you to confirm their identity</b></p>
 
-<p class="govuk-body">{{ voucherName }} would like to sign in to a government service. Before they can do this, they need to confirm their identity.<br><br>
+<p class="govuk-body">{{ voucheeName }} would like to sign in to a government service. Before they can do this, they need to confirm their identity.<br><br>
 
-{{ voucherName }} would like you to confirm their identity for them. </p>
+{{ voucheeName }} would like you to confirm their identity for them. </p>
 
 <p class="govuk-body"><b>What you need to do</b></p>
 
 <p class="govuk-body"> We’ll ask you to:<br>
 <ul class="govuk-list govuk-list--bullet">
 <li>confirm your identity by entering your passport or driving licence details, or by taking other forms of ID to a Post Office</li>
-<li>look at 6 photos and confirm which photo is of {{ voucherName }}</li>
+<li>look at 6 photos and confirm which photo is of {{ voucheeName }}</li>
 
 </ul>
 
@@ -23,7 +23,7 @@
 <b>How to do it</b> <br><br>
 Go to <a href='/vouch/vouch-for-someone' class="govuk-link">www.gov.uk/confirm-identity </a><br><br>
 
-You have 2 weeks to confirm {{ voucherName }}’s identity. After 2 weeks this request will expire and you will not be able to confirm their identity.<br><br>
+You have 2 weeks to confirm {{ voucheeName }}’s identity. After 2 weeks this request will expire and you will not be able to confirm their identity.<br><br>
 
 Digital Identity<br><br>
 GOV.UK<br><br>

--- a/src/views/govuk/vouch-for-someone.njk
+++ b/src/views/govuk/vouch-for-someone.njk
@@ -5,11 +5,11 @@
 {% set serviceName = "GOV.UK" %}
 
 {% block content %}
-<h1 class="govuk-heading-xl">Confirm {{ voucherName }}’s identity  </h1>
-    <p class="govuk-body">To confirm {{ voucherName }}’s identity you must:</p>
+<h1 class="govuk-heading-xl">Confirm {{ voucheeName }}’s identity  </h1>
+    <p class="govuk-body">To confirm {{ voucheeName }}’s identity you must:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>have a valid UK passport or driving licence </li>
-      <li>have known {{ voucherName }} for at least 2 years </li>
+      <li>have known {{ voucheeName }} for at least 2 years </li>
     </ul>
 
     <a href="/vouch/vouch-for-someone/use-saved-proof-of-identity" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
@@ -21,6 +21,6 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>    <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak" data-govspeak-module-started="true">
       <p class="govuk-body">You’ll need your passport or driving licence details. </p>
-      <p class="govuk-body">You’ll be asked to confirm {{ voucherName }}’s full name. You’ll also need to identify {{ voucherName }} from a series of photos.</p>
+      <p class="govuk-body">You’ll be asked to confirm {{ voucheeName }}’s full name. You’ll also need to identify {{ voucheeName }} from a series of photos.</p>
     </div>
 {% endblock %}

--- a/src/views/govuk/vouch-for-someone.njk
+++ b/src/views/govuk/vouch-for-someone.njk
@@ -5,20 +5,11 @@
 {% set serviceName = "GOV.UK" %}
 
 {% block content %}
-<h1 class="govuk-heading-xl">Confirm Kate Smith’s identity  </h1>
-    <p class="govuk-body">To confirm Kate’s identity you must:</p>
+<h1 class="govuk-heading-xl">Confirm {{ voucherName }}’s identity  </h1>
+    <p class="govuk-body">To confirm {{ voucherName }}’s identity you must:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>have a valid UK passport or driving licence </li>
-      <li>have known Kate for at least 2 years </li>
-      <li>be in a <a href ="https://www.gov.uk/government/publications/how-to-accept-a-vouch-as-evidence-of-someones-identity/who-can-vouch-for-someones-identity"> position of authority in your community</a> </li>
-    </ul>
-
-    <p class="govuk-body">You must not:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>be a family member of Kate </li>
-      <li>be in a relationship with Kate</li>
-      <li>live at the same address as Kate </li>
-      <li>have confirmed someone else’s identity that you knew was false in the past 5 years </li>
+      <li>have known {{ voucherName }} for at least 2 years </li>
     </ul>
 
     <a href="/vouch/vouch-for-someone/use-saved-proof-of-identity" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
@@ -30,26 +21,6 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>    <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak" data-govspeak-module-started="true">
       <p class="govuk-body">You’ll need your passport or driving licence details. </p>
-      <p class="govuk-body">You’ll be asked to confirm Kate’s full name, date of birth and address. You’ll also need to identify Kate from a series of photos.</p>
+      <p class="govuk-body">You’ll be asked to confirm {{ voucherName }}’s full name. You’ll also need to identify {{ voucherName }} from a series of photos.</p>
     </div>
-{% endblock %}
-{% block sideContent %}
-  <h2 class="govuk-heading-m" id="subsection-title">
-    Related content
-  </h2>
-  <nav role="navigation" aria-labelledby="subsection-title">
-    <ul class="govuk-list govuk-!-font-size-16">
-      <li>
-        <a class="govuk-link"  class="govuk-link" href="#">
-          Criminal record checks when you apply for a role
-        </a>
-      </li>
-      <li>
-        <a class="govuk-link"  class="govuk-link" href="#">
-          Find out which DBS check is right for your employee
-        </a>
-      </li>
-
-    </ul>
-  </nav>
 {% endblock %}

--- a/src/views/govuk/vouch-for-someone.njk
+++ b/src/views/govuk/vouch-for-someone.njk
@@ -21,7 +21,7 @@
       <li>have confirmed someone else’s identity that you knew was false in the past 5 years </li>
     </ul>
 
-    <a href="/gov-account" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+    <a href="/vouch/vouch-for-someone/use-saved-proof-of-identity" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
       Start
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -18,7 +18,7 @@
   <div>
   {{ govukButton({
       text: "Vouch for someone else",
-      href: "/"
+      href: "/emails/voucher-request?voucheeName=Anne Example"
   }) }}
   </div>
 

--- a/src/views/vouch/request-vouch/done.njk
+++ b/src/views/vouch/request-vouch/done.njk
@@ -6,7 +6,7 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl">Your details have been submitted</h1>
-  <p class="govuk-body">We have sent an email to VoucherName with instructions for how they can confirm your identity.</p>
+  <p class="govuk-body">We have sent an email to voucheeName with instructions for how they can confirm your identity.</p>
   <p class="govuk-body">We will send a confirmation email to you once your identity has been confirmed.</p>
-  <p class="govuk-body">If VoucherName cannot confirm your identity within 2 weeks, you will need to ask someone else to confirm your identity and <a href="/vouch/request-vouch" class="govuk-link">start again</a>.</p>  
+  <p class="govuk-body">If voucheeName cannot confirm your identity within 2 weeks, you will need to ask someone else to confirm your identity and <a href="/vouch/request-vouch" class="govuk-link">start again</a>.</p>  
 {% endblock %}

--- a/src/views/vouch/vouch-for-someone/confirm-details.njk
+++ b/src/views/vouch/vouch-for-someone/confirm-details.njk
@@ -2,8 +2,8 @@
 
 {% block content %}
 <form class="form" action="/vouch/vouch-for-someone/confirm-details" method="post">
-  <h1 class="govuk-heading-xl">Confirm Person's details</h1>
-  <p class="govuk-body">Check that Person's details are correct.</p>
+  <h1 class="govuk-heading-xl">Confirm {{ voucherName }}'s details</h1>
+  <p class="govuk-body">Check that {{ voucherName }}'s details are correct.</p>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <div class="govuk-summary-list__row">
@@ -11,7 +11,7 @@
         Full name
       </dt>
       <dd class="govuk-summary-list__value">
-        Person Name
+        {{ voucherName }}
       </dd>
     </div>
 
@@ -21,25 +21,6 @@
       </dt>
       <dd class="govuk-summary-list__value">
         <img src="https://thispersondoesnotexist.com/image" alt="Face" width="150" height="150">
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="govuk-summary-list__value">
-        01/01/1990
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Address
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <p class="govuk-body">
-          1 High Street<br>Watford WD1 1AA</p>
       </dd>
     </div>
   </dl>
@@ -53,7 +34,7 @@
     </strong>
   </div>
   <p class="govuk-body">I confirm that to the best of my knowledge the information I have provided is correct and complete.</p>
-  <p class="govuk-body">I confirm that I have known Person Name for at least 2 years. </p>
+  <p class="govuk-body">I confirm that I have known {{ voucherName }} for at least 2 years. </p>
 
   <div>
     <button class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/src/views/vouch/vouch-for-someone/confirm-details.njk
+++ b/src/views/vouch/vouch-for-someone/confirm-details.njk
@@ -2,8 +2,8 @@
 
 {% block content %}
 <form class="form" action="/vouch/vouch-for-someone/confirm-details" method="post">
-  <h1 class="govuk-heading-xl">Confirm {{ voucherName }}'s details</h1>
-  <p class="govuk-body">Check that {{ voucherName }}'s details are correct.</p>
+  <h1 class="govuk-heading-xl">Confirm {{ voucheeName }}'s details</h1>
+  <p class="govuk-body">Check that {{ voucheeName }}'s details are correct.</p>
 
   <dl class="govuk-summary-list govuk-!-margin-bottom-9">
     <div class="govuk-summary-list__row">
@@ -11,7 +11,7 @@
         Full name
       </dt>
       <dd class="govuk-summary-list__value">
-        {{ voucherName }}
+        {{ voucheeName }}
       </dd>
     </div>
 
@@ -34,7 +34,7 @@
     </strong>
   </div>
   <p class="govuk-body">I confirm that to the best of my knowledge the information I have provided is correct and complete.</p>
-  <p class="govuk-body">I confirm that I have known {{ voucherName }} for at least 2 years. </p>
+  <p class="govuk-body">I confirm that I have known {{ voucheeName }} for at least 2 years. </p>
 
   <div>
     <button class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/src/views/vouch/vouch-for-someone/confirm-likeness.njk
+++ b/src/views/vouch/vouch-for-someone/confirm-likeness.njk
@@ -7,10 +7,10 @@
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading">
-          Which of these photos is of Person?
+          Which of these photos is of {{ voucherName }}?
         </h1>
       </legend>
-      <p class="govuk-body">Select the photo of Person.</p>
+      <p class="govuk-body">Select the photo of {{ voucherName }}.</p>
 
       <div class="govuk-radios" data-module="govuk-radios">
         <div class="govuk-radios__item">

--- a/src/views/vouch/vouch-for-someone/confirm-likeness.njk
+++ b/src/views/vouch/vouch-for-someone/confirm-likeness.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<form class="form" action="/vouch/vouch-for-someone/confirm-details" method="post">
+<form class="form" action="/vouch/vouch-for-someone/confirm-likeness" method="post">
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/src/views/vouch/vouch-for-someone/confirm-likeness.njk
+++ b/src/views/vouch/vouch-for-someone/confirm-likeness.njk
@@ -7,10 +7,10 @@
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading">
-          Which of these photos is of {{ voucherName }}?
+          Which of these photos is of {{ voucheeName }}?
         </h1>
       </legend>
-      <p class="govuk-body">Select the photo of {{ voucherName }}.</p>
+      <p class="govuk-body">Select the photo of {{ voucheeName }}.</p>
 
       <div class="govuk-radios" data-module="govuk-radios">
         <div class="govuk-radios__item">

--- a/src/views/vouch/vouch-for-someone/done.njk
+++ b/src/views/vouch/vouch-for-someone/done.njk
@@ -2,9 +2,9 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl">Your details have been submitted</h1>
-  <p class="govuk-body">Thank you for confirming Person Name's identity. </p>
+  <p class="govuk-body">Thank you for confirming {{ voucherName }}’s identity. </p>
   <p class="govuk-body">We have sent you an email with a copy of your responses.</p>
-  <p class="govuk-body">We have sent Person Name an email to say you have confirmed their identity.</p>
+  <p class="govuk-body">We have sent {{ voucherName }} an email to say you have confirmed their identity.</p>
   <p class="govuk-body">You do not need to take any further action and we will email you if we need to.</p>
   <p class="govuk-body">Digital Identity </br>GOV.UK</p>
 {% endblock %}

--- a/src/views/vouch/vouch-for-someone/done.njk
+++ b/src/views/vouch/vouch-for-someone/done.njk
@@ -2,9 +2,9 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl">Your details have been submitted</h1>
-  <p class="govuk-body">Thank you for confirming {{ voucherName }}’s identity. </p>
+  <p class="govuk-body">Thank you for confirming {{ voucheeName }}’s identity. </p>
   <p class="govuk-body">We have sent you an email with a copy of your responses.</p>
-  <p class="govuk-body">We have sent {{ voucherName }} an email to say you have confirmed their identity.</p>
+  <p class="govuk-body">We have sent {{ voucheeName }} an email to say you have confirmed their identity.</p>
   <p class="govuk-body">You do not need to take any further action and we will email you if we need to.</p>
   <p class="govuk-body">Digital Identity </br>GOV.UK</p>
 {% endblock %}


### PR DESCRIPTION
Join up the vouching journey to the start button on the prototype home screen.

This uses a placeholder name rather than pulling any information from the pod, and the lineup photos are a bit suspect, but we can now click through the whole of the vouching journey in a demo or for user testing. 

The placeholder name is pulled from a URL parameter on the starting email (supplied when clicking the button from the homepage). If you start the journey from elsewhere weird things might happen, so don't do that.