### PR TITLE
Remind users their photo will be shared

### DIFF
--- a/src/views/vouch/request-vouch/confirmation.njk
+++ b/src/views/vouch/request-vouch/confirmation.njk
@@ -49,7 +49,9 @@
   </dl>
 
   <p class="govuk-body">When you confirm, we'll email the person you've asked to vouch for your identity - they'll receive the email straight away.</p>
-
+  
+  <p class="govuk-body">Your photo will be sent to them so they can confirm it’s of you.</p>
+  
   <p class="govuk-body">They’ll have 14 days to vouch for your identity after they get the email.</p>
 
   <form action="/form-handler" method="post" novalidate>

--- a/src/views/vouch/request-vouch/provide-photo.njk
+++ b/src/views/vouch/request-vouch/provide-photo.njk
@@ -15,6 +15,7 @@
         <li>a jpg or jpeg file</li>
         <li>at least 50KB and no more than 10MB</li>
       </ul>
+      <p class="govuk-body">Your photo will be sent to the person you’re asking to confirm your identity.</p>
       <button class="govuk-button" data-module="govuk-button">Choose your photo</button>
     </form>
 {% endblock %}


### PR DESCRIPTION
Add reminders to the photo upload page and confirmation page that users' photos will be shared with the person vouching for them, so that they don't share photos they might not be comfortable sharing.