### PR TITLE
Allow anyone to vouch for anyone else

### DIFF
--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -216,6 +216,8 @@ export function confirmDetailsGet(req: Request, res: Response): void {
   if (req.session) {
     res.render("vouch/vouch-for-someone/confirm-details", {
       voucheeName: req.session.voucheeName,
+      relation: req.session.relation,
+      howLong: req.session.howLong,
     });
   }
 }

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -166,6 +166,22 @@ export function useSavedProofOfIdGet(req: Request, res: Response): void {
   res.render("vouch/vouch-for-someone/use-saved-proof-of-identity");
 }
 
+// Are you a direct relation?
+export function directRelationGet(req: Request, res: Response): void {
+  if (req.session) {
+    res.render("vouch/vouch-for-someone/relation", {
+      voucheeName: req.session.voucheeName,
+    });
+  }
+}
+
+export function directRelationPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.relation = req.body.relation;
+    res.redirect("/vouch/vouch-for-someone/confirm-details");
+  }
+}
+
 // Pick vouchee out of a line-up
 export function confirmLikenessGet(req: Request, res: Response): void {
   if (req.session) {

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -178,7 +178,23 @@ export function directRelationGet(req: Request, res: Response): void {
 export function directRelationPost(req: Request, res: Response): void {
   if (req.session) {
     req.session.relation = req.body.relation;
-    res.redirect("/vouch/vouch-for-someone/confirm-details");
+    res.redirect("/vouch/vouch-for-someone/how-long");
+  }
+}
+
+// How long have you known them?
+export function howLongGet(req: Request, res: Response): void {
+  if (req.session) {
+    res.render("vouch/vouch-for-someone/how-long", {
+      voucheeName: req.session.voucheeName,
+    });
+  }
+}
+
+export function howLongPost(req: Request, res: Response): void {
+  if (req.session) {
+    req.session.howLong = req.body["how-long"];
+    res.redirect("/vouch/vouch-for-someone/confirm-likeness");
   }
 }
 

--- a/src/controllers/vouch.ts
+++ b/src/controllers/vouch.ts
@@ -3,24 +3,16 @@ import fetch from "node-fetch";
 import path from "path";
 import { Request, Response } from "express";
 import { v4 as uuidv4 } from "uuid";
+import { getSessionFromStorage } from "@inrupt/solid-client-authn-node";
+import { universalAccess } from "@inrupt/solid-client";
+import type CookieSessionInterfaces from "cookie-session";
 import { Url } from "../lib/models/common";
 import { getHostname } from "../config";
-import { getSessionFromStorage } from "@inrupt/solid-client-authn-node";
 
-import { createVcBlob } from "../lib/pod"
-
-import {
-  universalAccess,
-} from "@inrupt/solid-client";
-
-import {
-  getDatasetUri,
-  writeVouchVcToPod
-} from "../lib/pod";
+import { createVcBlob, getDatasetUri, writeVouchVcToPod } from "../lib/pod";
 
 import SessionError from "../errors";
 import { VouchArtifact } from "../lib/models/vc";
-
 
 async function download(url: Url, fileName: string) {
   const filePath = path.join(__dirname, "../", `public/images/${fileName}`);
@@ -92,10 +84,13 @@ export function voucheeConfirmationGet(req: Request, res: Response): void {
   }
 }
 
-export async function voucheeConfirmationPost(req: Request, res: Response): Promise<void> {
+export async function voucheeConfirmationPost(
+  req: Request,
+  res: Response
+): Promise<void> {
   const session = await getSessionFromStorage(req.session?.sessionId);
   if (session && session.info && session.info.webId) {
-    const vouchRequestUUID = uuidv4()
+    const vouchRequestUUID = uuidv4();
 
     const containerUri = await getDatasetUri(
       session,
@@ -105,15 +100,16 @@ export async function voucheeConfirmationPost(req: Request, res: Response): Prom
     const fileUri = `${containerUri}/vouch-request-vc`;
 
     if (req.session) {
-      const appSession: CookieSessionInterfaces.CookieSessionObject = req.session
-      appSession.webId = session.info.webId
-      const blobFile = await createVcBlob(appSession)
-    
+      const appSession: CookieSessionInterfaces.CookieSessionObject =
+        req.session;
+      appSession.webId = session.info.webId;
+      const blobFile = await createVcBlob(appSession);
+
       const vouchArtifact: VouchArtifact = {
         file: blobFile,
-        fileUri: fileUri
-      }
-  
+        fileUri,
+      };
+
       await writeVouchVcToPod(session, vouchArtifact);
 
       // Set APC policy - Writing Vouch for VC
@@ -122,7 +118,7 @@ export async function voucheeConfirmationPost(req: Request, res: Response): Prom
         appSession.webId,
         { write: true },
         { fetch: session.fetch }
-      ) 
+      );
 
       // Set APC policy - For reading Vouch Request
       // universalAccess.setAgentAccess(
@@ -147,7 +143,9 @@ export function voucheeAcpGet(req: Request, res: Response): void {
 // Journey completion page
 export function voucheeDoneGet(req: Request, res: Response): void {
   if (req.session) {
-    res.render("vouch/request-vouch/done", { voucher: req.session.voucherEmail });
+    res.render("vouch/request-vouch/done", {
+      voucher: req.session.voucherEmail,
+    });
   }
 }
 

--- a/src/lib/models/vc.ts
+++ b/src/lib/models/vc.ts
@@ -1,19 +1,16 @@
-import { VouchRequest} from "./vouch"
 import { Blob } from "node:buffer";
+import { VouchRequest } from "./vouch";
 
-export type VerifiableCredentialPayloadType =
- | VouchRequestVC
-
-export type VerifiableCredentialType =
-| "VerifiableCredential"
-| "VouchRequest"
+export type VerifiableCredentialType = "VerifiableCredential" | "VouchRequest";
 
 export interface VouchRequestVC {
   "@context"?: string[];
   type?: VerifiableCredentialType[];
-  request?: VouchRequest
+  request?: VouchRequest;
   [k: string]: unknown;
 }
+
+export type VerifiableCredentialPayloadType = VouchRequestVC;
 
 export interface VouchArtifact {
   file: Blob;

--- a/src/routes/vouch.ts
+++ b/src/routes/vouch.ts
@@ -13,6 +13,8 @@ import {
   voucheeDoneGet,
   voucheeYourNamePost,
   voucheeProvidePhotoPost,
+  directRelationGet,
+  directRelationPost,
   confirmLikenessGet,
   confirmLikenessPost,
   confirmDetailsGet,
@@ -48,6 +50,8 @@ router.get(
   "/vouch-for-someone/use-saved-proof-of-identity",
   useSavedProofOfIdGet
 );
+router.get("/vouch-for-someone/relation", directRelationGet);
+router.post("/vouch-for-someone/relation", directRelationPost);
 router.get("/vouch-for-someone/confirm-likeness", confirmLikenessGet);
 router.post("/vouch-for-someone/confirm-likeness", confirmLikenessPost);
 router.get("/vouch-for-someone/confirm-details", confirmDetailsGet);

--- a/src/routes/vouch.ts
+++ b/src/routes/vouch.ts
@@ -15,6 +15,8 @@ import {
   voucheeProvidePhotoPost,
   directRelationGet,
   directRelationPost,
+  howLongGet,
+  howLongPost,
   confirmLikenessGet,
   confirmLikenessPost,
   confirmDetailsGet,
@@ -52,6 +54,8 @@ router.get(
 );
 router.get("/vouch-for-someone/relation", directRelationGet);
 router.post("/vouch-for-someone/relation", directRelationPost);
+router.get("/vouch-for-someone/how-long", howLongGet);
+router.post("/vouch-for-someone/how-long", howLongPost);
 router.get("/vouch-for-someone/confirm-likeness", confirmLikenessGet);
 router.post("/vouch-for-someone/confirm-likeness", confirmLikenessPost);
 router.get("/vouch-for-someone/confirm-details", confirmDetailsGet);

--- a/src/views/account/home.njk
+++ b/src/views/account/home.njk
@@ -38,7 +38,7 @@
     <p class="govuk-body">
       Someone who knows you can confirm your identity, if you need to prove who you are to a government service and do not have identity documents like a passport. This is known as ‘vouching’.
     </p>
-    <p class="govuk-body">Anyone can vouch for your identity. The longer they've known you, the stronger thir vouch will be.
+    <p class="govuk-body">Anyone can vouch for your identity. The longer they've known you, the stronger their vouch will be.
     </p>
     <p class="govuk-body">
       <a class="govuk-link" href="/vouch/request-vouch">Ask someone to vouch for your identity</a>

--- a/src/views/account/home.njk
+++ b/src/views/account/home.njk
@@ -38,7 +38,7 @@
     <p class="govuk-body">
       Someone who knows you can confirm your identity, if you need to prove who you are to a government service and do not have identity documents like a passport. This is known as ‘vouching’.
     </p>
-    <p class="govuk-body">Anyone who's known you for 2 years or more can vouch for your identity.
+    <p class="govuk-body">Anyone can vouch for your identity. The longer they've known you, the stronger thir vouch will be.
     </p>
     <p class="govuk-body">
       <a class="govuk-link" href="/vouch/request-vouch">Ask someone to vouch for your identity</a>

--- a/src/views/govuk/request-vouch.njk
+++ b/src/views/govuk/request-vouch.njk
@@ -10,7 +10,6 @@
     <p class="govuk-body">The person you ask must:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>have a valid UK passport or driving licence </li>
-      <li>have known you for at least 2 years </li>
       <li>have an email address we can contact them on. You will need to know their email address before you begin</li>
     </ul>
 

--- a/src/views/govuk/vouch-for-someone.njk
+++ b/src/views/govuk/vouch-for-someone.njk
@@ -6,11 +6,7 @@
 
 {% block content %}
 <h1 class="govuk-heading-xl">Confirm {{ voucheeName }}’s identity  </h1>
-    <p class="govuk-body">To confirm {{ voucheeName }}’s identity you must:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>have a valid UK passport or driving licence </li>
-      <li>have known {{ voucheeName }} for at least 2 years </li>
-    </ul>
+    <p class="govuk-body">To confirm {{ voucheeName }}’s identity you must have a valid UK passport or driving licence.</p>
 
     <a href="/vouch/vouch-for-someone/use-saved-proof-of-identity" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
       Start
@@ -21,6 +17,6 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>    <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak" data-govspeak-module-started="true">
       <p class="govuk-body">You’ll need your passport or driving licence details. </p>
-      <p class="govuk-body">You’ll be asked to confirm {{ voucheeName }}’s full name. You’ll also need to identify {{ voucheeName }} from a series of photos.</p>
+      <p class="govuk-body">You’ll be asked to confirm {{ voucheeName }}’s full name and how long you've known them. You’ll also need to identify {{ voucheeName }} from a series of photos.</p>
     </div>
 {% endblock %}

--- a/src/views/vouch/vouch-for-someone/confirm-details.njk
+++ b/src/views/vouch/vouch-for-someone/confirm-details.njk
@@ -23,6 +23,23 @@
         <img src="https://thispersondoesnotexist.com/image" alt="Face" width="150" height="150">
       </dd>
     </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Are you a direct relation?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ relation | capitalize }}
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        How long have you known them?
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ howLong | capitalize}}
+      </dd>
+    </div>
+
   </dl>
 
   <h2 class="govuk-heading-l">Declaration</h2>
@@ -34,7 +51,6 @@
     </strong>
   </div>
   <p class="govuk-body">I confirm that to the best of my knowledge the information I have provided is correct and complete.</p>
-  <p class="govuk-body">I confirm that I have known {{ voucheeName }} for at least 2 years. </p>
 
   <div>
     <button class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/src/views/vouch/vouch-for-someone/how-long.njk
+++ b/src/views/vouch/vouch-for-someone/how-long.njk
@@ -1,0 +1,29 @@
+{% extends "layouts/base.njk" %}
+
+{% block content %}
+
+<form class="form" action="/vouch/vouch-for-someone/how-long" method="post">
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+          How long have you known {{ voucheeName }}?
+        </h1>
+      </legend>
+
+      <select class="govuk-select" id="how-long" name="how-long">
+        <option value="Less than 6 months">Less than 6 months</option>
+        <option value="Between 6 months and 1 year">Between 6 months and 1 year</option>
+        <option value="Between 1 and 2 years">Between 1 and 2 years</option>
+        <option value="Between 2 and 3 years">Between 2 and 3 years</option>
+        <option value="More than 3 years">More than 3 years</option>
+      </select>
+      
+    </fieldset>
+  </div>
+
+  <div>
+    <button class="govuk-button" data-module="govuk-button">Continue</button>
+  </div>
+</form>
+{% endblock %}

--- a/src/views/vouch/vouch-for-someone/relation.njk
+++ b/src/views/vouch/vouch-for-someone/relation.njk
@@ -1,0 +1,38 @@
+{% extends "layouts/base.njk" %}
+
+{% block content %}
+
+<form class="form" action="/vouch/vouch-for-someone/relation" method="post">
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+          Are you a direct relation of {{ voucheeName }}?
+        </h1>
+      </legend>
+      <div id="relation-hint" class="govuk-hint">
+        A direct relation is a parent, child or sibling of {{ voucheeName }}.
+      </div>
+      <div class="govuk-radios" data-module="govuk-radios">
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="relation" name="relation" type="radio" value="yes">
+          <label class="govuk-label govuk-radios__label" for="relation">
+            Yes
+          </label>
+        </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="relation-2" name="relation" type="radio" value="no">
+          <label class="govuk-label govuk-radios__label" for="relation-2">
+            No
+          </label>
+        </div>
+      </div>
+      
+    </fieldset>
+  </div>
+
+  <div>
+    <button class="govuk-button" data-module="govuk-button">Continue</button>
+  </div>
+</form>
+{% endblock %}

--- a/src/views/vouch/vouch-for-someone/use-saved-proof-of-identity.njk
+++ b/src/views/vouch/vouch-for-someone/use-saved-proof-of-identity.njk
@@ -10,7 +10,7 @@
 
   <p class="govuk-body">{{ 'identity.useSavedIdentity.paragraph1' | translate }}</p>
 
-  <form action="/vouch/vouch-for-someone/confirm-likeness" method="get">
+  <form action="/vouch/vouch-for-someone/relation" method="get">
     {{ govukButton({
       text: 'general.continue' | translate,
       type: "submit"


### PR DESCRIPTION
In this prototype we want to explore the idea that anyone (who can prove their identity) can vouch for anyone else. We'd then evaluate the 'strength' of the vouch they've made, which would become a piece of evidence in the identity proving engine. In the future this could include things like 'a vouch made by a doctor or civil servant is stronger than a vouch from a citizen', but that's out of scope for this prototype.

In order to assess the strength of the vouch we need a little more information from the voucher. This PR adds two new pages to the vouching journey - asking the voucher if they're a direct relation to the vouchee and how long they've known them. 

This means we can drop the requirement that the voucher has known the vouchee for at least two years.